### PR TITLE
Make staged writes and cache-through reads reliable

### DIFF
--- a/core/backend_s3.go
+++ b/core/backend_s3.go
@@ -757,7 +757,21 @@ func (s *S3Backend) mpuCopyPart(from string, to string, mpuId string, bytes stri
 
 	s3Log.Debug(params)
 
-	resp, err := s.UploadPartCopy(params)
+	var resp *s3.UploadPartCopyOutput
+	var err error
+	for attempt := 1; attempt <= s3WriteRetryAttempts; attempt++ {
+		var req *request.Request
+		req, resp = s.UploadPartCopyRequest(params)
+		err = req.Send()
+		if err == nil {
+			break
+		}
+		if !shouldRetry(err) || attempt == s3WriteRetryAttempts {
+			break
+		}
+		s3Log.Warnf("UploadPartCopy retrying key=%s part=%d attempt=%d/%d err=%v", to, part, attempt, s3WriteRetryAttempts, err)
+		time.Sleep(s3WriteRetryDelay(attempt))
+	}
 	if err != nil {
 		s3Log.Warnf("UploadPartCopy %v = %v", params, err)
 		return nil, err

--- a/core/backend_s3_test.go
+++ b/core/backend_s3_test.go
@@ -3,7 +3,16 @@ package core
 import (
 	"crypto/md5"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/yandex-cloud/geesefs/core/cfg"
 )
 
 func TestShouldUseMultipartCopyAvoidsMetadataSelfCopy(t *testing.T) {
@@ -46,5 +55,44 @@ func TestExpectedMultipartETagRejectsOpaquePartETag(t *testing.T) {
 	opaque := "opaque-etag"
 	if got := expectedMultipartETag([]*string{&opaque}, 1); got != nil {
 		t.Fatalf("expected opaque multipart etag to be rejected, got %s", *got)
+	}
+}
+
+func TestMultipartCopyPartRetriesTransientInternalError(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) == 1 {
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = fmt.Fprint(w, `<Error><Code>InternalError</Code><Message>retry me</Message></Error>`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = fmt.Fprint(w, `<CopyPartResult><ETag>"part-etag"</ETag><LastModified>2026-07-16T00:00:00Z</LastModified></CopyPartResult>`)
+	}))
+	defer server.Close()
+
+	client := s3.New(session.Must(session.NewSession(aws.NewConfig().
+		WithCredentials(credentials.NewStaticCredentials("key", "secret", "")).
+		WithEndpoint(server.URL).
+		WithRegion("us-east-1").
+		WithS3ForcePathStyle(true).
+		WithMaxRetries(0))))
+	backend := &S3Backend{
+		S3:     client,
+		bucket: "bucket",
+		flags:  cfg.DefaultFlags(),
+		config: &cfg.S3Config{},
+	}
+
+	etag, err := backend.mpuCopyPart("bucket/source", "destination", "upload-id", "bytes=0-241", 1, nil)
+	if err != nil {
+		t.Fatalf("multipart copy part failed after transient error: %v", err)
+	}
+	if etag == nil || *etag != `"part-etag"` {
+		t.Fatalf("etag = %v, want part-etag", etag)
+	}
+	if got := requests.Load(); got != 2 {
+		t.Fatalf("requests = %d, want 2", got)
 	}
 }

--- a/core/cfg/flags.go
+++ b/core/cfg/flags.go
@@ -364,8 +364,8 @@ MISC OPTIONS:
 
 		cli.BoolFlag{
 			Name: "no-preload-dir",
-			Usage: "Disable directory listing pre-loading when you open individual files" +
-				" and don't do any READDIR calls. Default is to always pre-load listing" +
+			Usage: "Disable speculative directory listing pre-loading for file lookups and READDIR." +
+				" READDIR still lists the requested directory with a delimiter. Default is to pre-load listings" +
 				" which helps in a lot of cases, for example when you use rsync. Note" +
 				" that you should also enable --no-implicit-dir if you want to fully avoid" +
 				" ListObjects requests during file lookups.",

--- a/core/dir.go
+++ b/core/dir.go
@@ -1651,24 +1651,15 @@ func (parent *Inode) Rename(from string, newParent *Inode, to string) (err error
 		renameRecursive(fromInode, newParent, to)
 	} else {
 		// Handle staged file renames
-		if fromInode.StagedFile != nil && fromInode.StagedFile.FD != nil {
-
+		if stagedFile := fromInode.StagedFile; stagedFile != nil {
 			fs := fromInode.fs
-			oldStagedPath := fromInode.StagedFile.FD.Name()
 			newStagedDir := fs.flags.StagedWritePath + "/" + newParent.FullName()
 			newStagedPath := appendChildName(newStagedDir, to)
 
-			if err := os.MkdirAll(newStagedDir, fs.flags.DirMode); err == nil {
-				err := os.Rename(oldStagedPath, newStagedPath)
-				if err == nil {
-					// Reopen the file descriptor at the new path
-					newFD, openErr := os.OpenFile(newStagedPath, os.O_RDWR, fs.flags.FileMode)
-					if openErr == nil {
-						oldFD := fromInode.StagedFile.FD
-						fromInode.StagedFile.FD = newFD
-						oldFD.Close()
-					}
-				}
+			if err := os.MkdirAll(newStagedDir, fs.flags.DirMode); err != nil {
+				log.Warnf("Failed to create staged file directory during rename: %v", err)
+			} else if err := stagedFile.moveTo(newStagedPath); err != nil {
+				log.Warnf("Failed to move staged file during rename: %v", err)
 			}
 		}
 

--- a/core/dir.go
+++ b/core/dir.go
@@ -1650,19 +1650,7 @@ func (parent *Inode) Rename(from string, newParent *Inode, to string) (err error
 
 		renameRecursive(fromInode, newParent, to)
 	} else {
-		// Handle staged file renames
-		if stagedFile := fromInode.StagedFile; stagedFile != nil {
-			fs := fromInode.fs
-			newStagedDir := fs.flags.StagedWritePath + "/" + newParent.FullName()
-			newStagedPath := appendChildName(newStagedDir, to)
-
-			if err := os.MkdirAll(newStagedDir, fs.flags.DirMode); err != nil {
-				log.Warnf("Failed to create staged file directory during rename: %v", err)
-			} else if err := stagedFile.moveTo(newStagedPath); err != nil {
-				log.Warnf("Failed to move staged file during rename: %v", err)
-			}
-		}
-
+		// Staged data has a generation-specific path; only the logical inode moves.
 		renameInCache(fromInode, newParent, to)
 	}
 

--- a/core/dir.go
+++ b/core/dir.go
@@ -671,7 +671,8 @@ func (dh *DirHandle) loadListing() error {
 	// we immediately switch to regular listings.
 	// Original implementation in Goofys in fact was similar in this aspect
 	// but it was ugly in several places, so ... sorry, it's reworked. O:-)
-	useSlurp := parent.dir.listMarker == "" && parent.fs.flags.StatCacheTTL != 0
+	useSlurp := parent.dir.listMarker == "" && parent.fs.flags.StatCacheTTL != 0 &&
+		!parent.fs.flags.NoPreloadDir
 
 	// the dir expired, so we need to fetch from the cloud. there
 	// may be static directories that we want to keep, so cloud
@@ -2018,91 +2019,86 @@ func (parent *Inode) LookUpInodeMaybeDir(name string) (*BlobItemOutput, error) {
 	key := appendChildName(parentKey, name)
 	parent.logFuse("Inode.LookUp", key)
 
-	var object, dirObject *HeadBlobOutput
-	var prefixList *ListBlobsOutput
-	var objectError, dirError, prefixError error
-	results := make(chan int, 3)
-	n := 0
-
-	for {
-		n++
-		go func() {
-			object, objectError = cloud.HeadBlob(&HeadBlobInput{Key: key})
-			results <- 1
-		}()
-		if cloud.Capabilities().DirBlob {
-			<-results
-			break
-		}
-		if parent.fs.flags.Cheap {
-			<-results
-			if mapAwsError(objectError) != syscall.ENOENT {
-				break
+	type lookupResult struct {
+		blob *BlobItemOutput
+		err  error
+	}
+	lookups := []func() lookupResult{
+		func() lookupResult {
+			object, err := cloud.HeadBlob(&HeadBlobInput{Key: key})
+			if object == nil {
+				return lookupResult{err: err}
 			}
-		}
+			return lookupResult{blob: &object.BlobItemOutput, err: err}
+		},
+	}
 
+	if !cloud.Capabilities().DirBlob {
 		if !parent.fs.flags.NoDirObject {
-			n++
-			go func() {
-				dirObject, dirError = cloud.HeadBlob(&HeadBlobInput{Key: key + "/"})
-				results <- 2
-			}()
-			if parent.fs.flags.Cheap {
-				<-results
-				if mapAwsError(dirError) != syscall.ENOENT {
-					break
+			lookups = append(lookups, func() lookupResult {
+				object, err := cloud.HeadBlob(&HeadBlobInput{Key: key + "/"})
+				if object == nil {
+					return lookupResult{err: err}
 				}
-			}
+				return lookupResult{blob: &object.BlobItemOutput, err: err}
+			})
 		}
-
 		if !parent.fs.flags.ExplicitDir {
-			n++
-			go func() {
-				prefixList, prefixError = RetryListBlobs(parent.fs.flags, cloud, &ListBlobsInput{
+			lookups = append(lookups, func() lookupResult {
+				listing, err := RetryListBlobs(parent.fs.flags, cloud, &ListBlobsInput{
 					Delimiter: PString("/"),
 					MaxKeys:   PUInt32(1),
 					Prefix:    PString(key + "/"),
 				})
-				results <- 3
-			}()
-			if parent.fs.flags.Cheap {
-				<-results
+				if err != nil || listing == nil || len(listing.Prefixes) == 0 && len(listing.Items) == 0 {
+					return lookupResult{err: err}
+				}
+				if len(listing.Items) != 0 && listing.Items[0].Key != nil &&
+					(*listing.Items[0].Key == key || strings.HasPrefix(*listing.Items[0].Key, key+"/")) {
+					return lookupResult{blob: &listing.Items[0]}
+				}
+				return lookupResult{blob: &BlobItemOutput{Key: PString(key + "/")}}
+			})
+		}
+	}
+
+	if parent.fs.flags.Cheap {
+		for _, lookup := range lookups {
+			result := lookup()
+			if result.blob != nil {
+				return result.blob, nil
+			}
+			if result.err != nil && mapAwsError(result.err) != syscall.ENOENT {
+				return nil, result.err
 			}
 		}
-
-		break
+		return nil, syscall.ENOENT
 	}
 
-	for n > 0 {
-		n--
-		if !cloud.Capabilities().DirBlob && !parent.fs.flags.Cheap {
-			<-results
-		}
-		if object != nil {
-			return &object.BlobItemOutput, nil
-		}
-		if dirObject != nil {
-			return &dirObject.BlobItemOutput, nil
-		}
-		if prefixList != nil && (len(prefixList.Prefixes) != 0 || len(prefixList.Items) != 0) {
-			if len(prefixList.Items) != 0 && (*prefixList.Items[0].Key == key ||
-				(*prefixList.Items[0].Key)[0:len(key)+1] == key+"/") {
-				return &prefixList.Items[0], nil
-			}
-			return &BlobItemOutput{
-				Key: PString(key + "/"),
-			}, nil
-		}
+	type indexedResult struct {
+		index int
+		lookupResult
+	}
+	completed := make(chan indexedResult, len(lookups))
+	for i, lookup := range lookups {
+		go func(index int, lookup func() lookupResult) {
+			completed <- indexedResult{index: index, lookupResult: lookup()}
+		}(i, lookup)
 	}
 
-	if objectError != nil && mapAwsError(objectError) != syscall.ENOENT {
-		return nil, objectError
+	results := make([]lookupResult, len(lookups))
+	for range lookups {
+		result := <-completed
+		if result.blob != nil {
+			return result.blob, nil
+		}
+		results[result.index] = result.lookupResult
 	}
-	if dirError != nil && mapAwsError(dirError) != syscall.ENOENT {
-		return nil, dirError
-	}
-	if prefixError != nil && mapAwsError(prefixError) != syscall.ENOENT {
-		return nil, prefixError
+
+	for _, result := range results {
+		if result.err != nil && mapAwsError(result.err) != syscall.ENOENT {
+			return nil, result.err
+		}
 	}
 	return nil, syscall.ENOENT
 }

--- a/core/file.go
+++ b/core/file.go
@@ -227,6 +227,7 @@ func (fh *FileHandle) getOrCreateStagedFile() (err error) {
 	fh.inode.StagedFile = &StagedFile{
 		FH:          fh,
 		FD:          stagingFD,
+		localPath:   stagingPath,
 		mu:          sync.Mutex{},
 		lastWriteAt: time.Now(),
 		lastReadAt:  time.Now(),

--- a/core/file.go
+++ b/core/file.go
@@ -213,22 +213,24 @@ func (fh *FileHandle) getOrCreateStagedFile() (err error) {
 		return nil
 	}
 
-	stagingPath := filepath.Join(fh.inode.fs.flags.StagedWritePath, fh.inode.FullName())
-	parentDir := filepath.Dir(stagingPath)
+	parentDir := filepath.Join(fh.inode.fs.flags.StagedWritePath, filepath.Dir(fh.inode.FullName()))
 	if err := os.MkdirAll(parentDir, fh.inode.fs.flags.DirMode); err != nil {
 		return err
 	}
 
-	stagingFD, err := os.OpenFile(stagingPath, os.O_CREATE|os.O_RDWR, fh.inode.fs.flags.FileMode)
+	stagingFD, err := os.CreateTemp(parentDir, ".geesefs-staged-*")
 	if err != nil {
+		return err
+	}
+	if err := stagingFD.Chmod(fh.inode.fs.flags.FileMode); err != nil {
+		stagingFD.Close()
+		_ = os.Remove(stagingFD.Name())
 		return err
 	}
 
 	fh.inode.StagedFile = &StagedFile{
 		FH:          fh,
 		FD:          stagingFD,
-		localPath:   stagingPath,
-		mu:          sync.Mutex{},
 		lastWriteAt: time.Now(),
 		lastReadAt:  time.Now(),
 		shouldFlush: false,
@@ -254,12 +256,9 @@ func (fh *FileHandle) WriteFileStaged(offset int64, data []byte) (err error) {
 	}
 
 	if fh.inode.fs.flags.StagedWriteModeEnabled {
-		_, ok := fh.inode.fs.stagedFiles.Load(fh.inode.Id)
-		if !ok {
-			err = fh.getOrCreateStagedFile()
-			if err != nil {
-				return err
-			}
+		err = fh.getOrCreateStagedFile()
+		if err != nil {
+			return err
 		}
 	}
 
@@ -270,14 +269,25 @@ func (fh *FileHandle) WriteFileStaged(offset int64, data []byte) (err error) {
 	}
 	defer fh.inode.mu.Unlock()
 
-	_, err = fh.inode.StagedFile.FD.WriteAt(data, offset)
+	stagedFile := fh.inode.StagedFile
+	if stagedFile == nil {
+		return syscall.EAGAIN
+	}
+	stagedFile.mu.Lock()
+	if stagedFile.FD == nil || stagedFile.cleanupPending {
+		stagedFile.mu.Unlock()
+		return syscall.EAGAIN
+	}
+	_, err = stagedFile.FD.WriteAt(data, offset)
 	if err != nil {
+		stagedFile.mu.Unlock()
 		return err
 	}
-
-	fh.inode.StagedFile.mu.Lock()
-	fh.inode.StagedFile.lastWriteAt = time.Now()
-	fh.inode.StagedFile.mu.Unlock()
+	stagedFile.generation++
+	stagedFile.awaitingRemoteRename = false
+	stagedFile.shouldFlush = true
+	stagedFile.lastWriteAt = time.Now()
+	stagedFile.mu.Unlock()
 
 	fh.inode.checkPauseWriters()
 	if fh.inode.Attributes.Size < end {
@@ -1215,7 +1225,7 @@ func (inode *Inode) recordFlushError(err error) {
 
 func (inode *Inode) TryFlush(priority int) bool {
 	inode.mu.Lock()
-	if inode.StagedFile != nil {
+	if inode.hasUnpersistedStagedFileLocked() {
 		// Staged-write files are persisted by Goofys.flushStagedFileDirect.
 		// Letting the generic dirty-part flusher run here can try to copy
 		// ranges from a cloud object that has not been created yet.
@@ -1236,6 +1246,9 @@ func (inode *Inode) TryFlush(priority int) bool {
 	inode.mu.Lock()
 	defer inode.mu.Unlock()
 	if inode.Parent != parent {
+		return false
+	}
+	if inode.hasUnpersistedStagedFileLocked() {
 		return false
 	}
 
@@ -1266,6 +1279,11 @@ func (inode *Inode) TryFlush(priority int) bool {
 	}
 
 	return false
+}
+
+// LOCKS_REQUIRED(inode.mu)
+func (inode *Inode) hasUnpersistedStagedFileLocked() bool {
+	return inode.StagedFile != nil && !inode.StagedFile.AwaitingRemoteRename()
 }
 
 func (inode *Inode) sendUpload(priority int) bool {
@@ -1413,43 +1431,77 @@ func (inode *Inode) sendRename() {
 					err = nil
 					notFoundIgnore = true
 				} else if mappedErr == syscall.ENOENT || mappedErr == syscall.ERANGE {
-					s3Log.Warnf("Conflict detected (inode %v): failed to copy %v to %v: %v. File is removed remotely, dropping cache", inode.Id, from, key, err)
 					inode.mu.Lock()
-					newParent := inode.Parent
-					oldParent := inode.oldParent
-					oldName := inode.oldName
-					inode.oldParent = nil
-					inode.oldName = ""
-					inode.renamingTo = false
-					inode.resetCache()
-					inode.mu.Unlock()
-					newParent.removeChild(inode)
-					if oldParent != nil {
-						oldParent.mu.Lock()
-						if _, ok := oldParent.dir.DeletedChildren[oldName]; ok {
-							delete(oldParent.dir.DeletedChildren, oldName)
-							oldParent.addModified(-1)
+					stagedFile := inode.StagedFile
+					retryFromLocal := stagedFile != nil && stagedFile.AwaitingRemoteRename() && stagedFile.PrepareDirectUpload()
+					if retryFromLocal {
+						retryParent := inode.oldParent
+						retryName := inode.oldName
+						inode.oldParent = nil
+						inode.oldName = ""
+						inode.renamingTo = false
+						inode.recordFlushError(nil)
+						if inode.CacheState == ST_CACHED {
+							inode.SetCacheState(ST_MODIFIED)
 						}
-						oldParent.mu.Unlock()
+						inode.mu.Unlock()
+
+						s3Log.Warnf("Remote rename source %v was unavailable for inode %v; preserving the staged generation and uploading %v directly", from, inode.Id, key)
+						if retryParent != nil {
+							retryParent.mu.Lock()
+							if retryParent.dir.DeletedChildren[retryName] == inode {
+								delete(retryParent.dir.DeletedChildren, retryName)
+								retryParent.addModified(-1)
+							}
+							retryParent.mu.Unlock()
+						}
+						inode.fs.WakeupFlusher()
+					} else {
+						newParent := inode.Parent
+						conflictParent := inode.oldParent
+						conflictName := inode.oldName
+						inode.oldParent = nil
+						inode.oldName = ""
+						inode.renamingTo = false
+						inode.resetCache()
+						inode.mu.Unlock()
+
+						s3Log.Warnf("Conflict detected (inode %v): failed to copy %v to %v: %v. File is removed remotely, dropping cache", inode.Id, from, key, err)
+						newParent.removeChild(inode)
+						if conflictParent != nil {
+							conflictParent.mu.Lock()
+							if _, ok := conflictParent.dir.DeletedChildren[conflictName]; ok {
+								delete(conflictParent.dir.DeletedChildren, conflictName)
+								conflictParent.addModified(-1)
+							}
+							conflictParent.mu.Unlock()
+						}
 					}
 				} else {
 					log.Warnf("Failed to copy %v to %v (rename): %v", from, key, err)
 					inode.mu.Lock()
+					var completedStagedFile *StagedFile
+					var completedHash []byte
+					var completedSize uint64
 					inode.recordFlushError(err)
+					inode.renamingTo = false
 					if inode.Parent == oldParent && inode.Name == oldName {
 						// Someone renamed the inode back to the original name
 						// ...while we failed to copy it :)
 						inode.oldParent = nil
 						inode.oldName = ""
-						inode.renamingTo = false
 						inode.Parent.addModified(-1)
 						if (inode.CacheState == ST_MODIFIED || inode.CacheState == ST_CREATED) &&
-							!inode.isStillDirty() {
+							!inode.isStillDirty() && !inode.hasUnpersistedStagedFileLocked() {
 							inode.SetCacheState(ST_CACHED)
 							inode.SetAttrTime(time.Now())
 						}
+						completedStagedFile, completedHash, completedSize = inode.detachUploadedStagedFileLocked()
 					}
 					inode.mu.Unlock()
+					if completedStagedFile != nil {
+						inode.fs.finalizeStagedFile(inode, completedStagedFile, completedHash, completedSize)
+					}
 				}
 			}
 			if err == nil {
@@ -1458,6 +1510,9 @@ func (inode *Inode) sendRename() {
 				delParent := oldParent
 				delName := oldName
 				inode.mu.Lock()
+				var completedStagedFile *StagedFile
+				var completedHash []byte
+				var completedSize uint64
 				// Now we know that the object is accessible by the new name
 				if inode.Parent == newParent && inode.Name == newName {
 					// Just clear the old path
@@ -1477,12 +1532,16 @@ func (inode *Inode) sendRename() {
 					inode.oldName = newName
 				}
 				if (inode.CacheState == ST_MODIFIED || inode.CacheState == ST_CREATED) &&
-					!inode.isStillDirty() {
+					!inode.isStillDirty() && !inode.hasUnpersistedStagedFileLocked() {
 					inode.SetCacheState(ST_CACHED)
 					inode.SetAttrTime(time.Now())
 				}
 				inode.renamingTo = false
+				completedStagedFile, completedHash, completedSize = inode.detachUploadedStagedFileLocked()
 				inode.mu.Unlock()
+				if completedStagedFile != nil {
+					inode.fs.finalizeStagedFile(inode, completedStagedFile, completedHash, completedSize)
+				}
 				// Now delete the old key
 				if !notFoundIgnore {
 					inode.fs.addInflightChange(delKey)
@@ -1523,6 +1582,22 @@ func (inode *Inode) sendRename() {
 		inode.fs.WakeupFlusher()
 		inode.mu.Unlock()
 	}()
+}
+
+// LOCKS_REQUIRED(inode.mu)
+func (inode *Inode) detachUploadedStagedFileLocked() (*StagedFile, []byte, uint64) {
+	if inode.oldParent != nil || inode.StagedFile == nil || !inode.StagedFile.AwaitingRemoteRename() {
+		return nil, nil, 0
+	}
+
+	stagedFile := inode.StagedFile
+	inode.StagedFile = nil
+	inode.fs.stagedFiles.Delete(inode.Id)
+	var hash []byte
+	if inode.userMetadata != nil {
+		hash = append(hash, inode.userMetadata[inode.fs.flags.HashAttr]...)
+	}
+	return stagedFile, hash, inode.Attributes.Size
 }
 
 func (inode *Inode) sendUpdateMeta() {
@@ -2139,9 +2214,7 @@ func (inode *Inode) resetCache() {
 	// Clean up staged file if present
 	if inode.StagedFile != nil {
 		inode.fs.stagedFiles.Delete(inode.Id)
-		if inode.StagedFile.FD != nil {
-			inode.StagedFile.Cleanup()
-		}
+		inode.StagedFile.Cleanup()
 		inode.StagedFile = nil
 	}
 

--- a/core/goofys.go
+++ b/core/goofys.go
@@ -1719,14 +1719,30 @@ func (fs *Goofys) flushStagedFileDirect(inode *Inode) (err error) {
 		return nil
 	}
 
-	localPath := stagedFile.FD.Name()
 	if syncErr := stagedFile.FD.Sync(); syncErr != nil {
 		stagedFile.mu.Unlock()
 		inode.mu.Unlock()
 		return syncErr
 	}
+	localPath, ok := stagedFile.pathLocked()
+	if !ok {
+		stagedFile.mu.Unlock()
+		inode.mu.Unlock()
+		return os.ErrClosed
+	}
+	localFile, openErr := os.Open(localPath)
+	if openErr != nil {
+		stagedFile.mu.Unlock()
+		inode.mu.Unlock()
+		return openErr
+	}
 	stagedFile.flushing = true
 	stagedFile.shouldFlush = true
+	flushWeight := fs.flags.MaxParallelParts
+	if flushWeight < 1 {
+		flushWeight = 1
+	}
+	inode.IsFlushing += flushWeight
 	stagedFile.mu.Unlock()
 
 	totalSize := inode.Attributes.Size
@@ -1737,17 +1753,21 @@ func (fs *Goofys) flushStagedFileDirect(inode *Inode) (err error) {
 	}
 	contentType := inode.fs.flags.GetMimeType(inode.FullName())
 	inode.mu.Unlock()
+	defer localFile.Close()
 
 	defer func() {
+		inode.mu.Lock()
+		inode.IsFlushing -= flushWeight
+		inode.mu.Unlock()
 		if err != nil {
 			stagedFile.ResetFlushForRetry()
-			fs.WakeupFlusher()
 		}
+		fs.WakeupFlusher()
 	}()
 
 	var hash []byte
 	if fs.flags.HashAttr != "" && totalSize >= fs.flags.MinFileSizeForHashKB*1024 {
-		hashString, hashErr := hashLocalFile(localPath)
+		hashString, hashErr := hashLocalFile(localFile, totalSize)
 		if hashErr != nil {
 			return hashErr
 		}
@@ -1765,7 +1785,7 @@ func (fs *Goofys) flushStagedFileDirect(inode *Inode) (err error) {
 	inode.mu.Unlock()
 
 	log.Debugf("Directly flushing staged file: inode=%s size=%d path=%s", inode.FullName(), totalSize, localPath)
-	resp, err := fs.uploadStagedFileDirect(cloud, key, localPath, totalSize, contentType, metadata)
+	resp, err := fs.uploadStagedFileDirect(cloud, key, localFile, totalSize, contentType, metadata)
 	if err != nil {
 		log.Warnf("Failed direct staged file flush for %s: %v", inode.FullName(), err)
 		inode.mu.Lock()
@@ -1790,22 +1810,23 @@ func (fs *Goofys) flushStagedFileDirect(inode *Inode) (err error) {
 	}
 	inode.mu.Unlock()
 
+	inode.mu.Lock()
+	var size uint64
+	size = inode.Attributes.Size
+	localPath, hasLocalPath := stagedFile.Path()
+	if inode.StagedFile == stagedFile {
+		inode.StagedFile = nil
+		inode.fs.stagedFiles.Delete(inode.Id)
+	}
+	inode.mu.Unlock()
+
 	preserveForCache := false
-	if fs.flags.CacheThroughModeEnabled && fs.flags.ExternalCacheClient != nil {
+	if fs.flags.CacheThroughModeEnabled && fs.flags.ExternalCacheClient != nil && hasLocalPath {
 		preserveForCache = fs.CacheFileInExternalCacheFromSource(inode, localPath, true)
 		if preserveForCache {
 			stagedFile.PreserveForCache(localPath)
 		}
 	}
-
-	inode.mu.Lock()
-	var size uint64
-	size = inode.Attributes.Size
-	if inode.StagedFile == stagedFile {
-		inode.StagedFile = nil
-	}
-	inode.fs.stagedFiles.Delete(inode.Id)
-	inode.mu.Unlock()
 
 	stagedFile.Cleanup()
 
@@ -1821,34 +1842,23 @@ func (fs *Goofys) flushStagedFileDirect(inode *Inode) (err error) {
 	return nil
 }
 
-func hashLocalFile(path string) (string, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return "", err
-	}
-	defer file.Close()
-
+func hashLocalFile(file *os.File, size uint64) (string, error) {
 	hasher := sha256.New()
 	buf := make([]byte, 4*1024*1024)
-	if _, err := io.CopyBuffer(hasher, file, buf); err != nil {
+	reader := io.NewSectionReader(file, 0, int64(size))
+	if _, err := io.CopyBuffer(hasher, reader, buf); err != nil {
 		return "", err
 	}
 	return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
-func (fs *Goofys) uploadStagedFileDirect(cloud StorageBackend, key, localPath string, size uint64, contentType *string, metadata map[string]*string) (*MultipartBlobCommitOutput, error) {
-	file, err := os.Open(localPath)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
+func (fs *Goofys) uploadStagedFileDirect(cloud StorageBackend, key string, file *os.File, size uint64, contentType *string, metadata map[string]*string) (*MultipartBlobCommitOutput, error) {
 	if size <= fs.flags.SinglePartMB*1024*1024 {
 		resp, err := cloud.PutBlob(&PutBlobInput{
 			Key:         key,
 			Metadata:    metadata,
 			ContentType: contentType,
-			Body:        file,
+			Body:        io.NewSectionReader(file, 0, int64(size)),
 			Size:        PUInt64(size),
 		})
 		if err != nil {

--- a/core/goofys.go
+++ b/core/goofys.go
@@ -1559,7 +1559,7 @@ func (fs *Goofys) flushStagedFileBuffered(inode *Inode) (err error) {
 
 	defer func() {
 		if err != nil {
-			stagedFile.ResetFlushForRetry()
+			stagedFile.FinishFlush(true)
 			fs.WakeupFlusher()
 		}
 	}()
@@ -1622,9 +1622,7 @@ func (fs *Goofys) flushStagedFileBuffered(inode *Inode) (err error) {
 				inode.UnlockRange(uint64(offset), chunkSize, true)
 
 				// Reset flushing state so it can be retried
-				stagedFile.mu.Lock()
-				stagedFile.flushing = false
-				stagedFile.mu.Unlock()
+				stagedFile.FinishFlush(true)
 
 				inode.mu.Unlock()
 				return nil // Exit and let readers proceed, staged file will be retried later
@@ -1683,6 +1681,7 @@ func (fs *Goofys) flushStagedFileBuffered(inode *Inode) (err error) {
 	inode.fs.stagedFiles.Delete(inode.Id)
 	inode.mu.Unlock()
 
+	stagedFile.FinishFlush(false)
 	stagedFile.Cleanup()
 
 	if fs.flags.EventCallback != nil {
@@ -1705,9 +1704,13 @@ func (fs *Goofys) flushStagedFileDirect(inode *Inode) (err error) {
 		inode.mu.Unlock()
 		return nil
 	}
+	if inode.renamingTo {
+		inode.mu.Unlock()
+		return nil
+	}
 
 	stagedFile.mu.Lock()
-	if stagedFile.flushing {
+	if stagedFile.flushing || stagedFile.awaitingRemoteRename {
 		stagedFile.mu.Unlock()
 		inode.mu.Unlock()
 		return nil
@@ -1724,18 +1727,9 @@ func (fs *Goofys) flushStagedFileDirect(inode *Inode) (err error) {
 		inode.mu.Unlock()
 		return syncErr
 	}
-	localPath, ok := stagedFile.pathLocked()
-	if !ok {
-		stagedFile.mu.Unlock()
-		inode.mu.Unlock()
-		return os.ErrClosed
-	}
-	localFile, openErr := os.Open(localPath)
-	if openErr != nil {
-		stagedFile.mu.Unlock()
-		inode.mu.Unlock()
-		return openErr
-	}
+	localFile := stagedFile.FD
+	localPath := localFile.Name()
+	flushGeneration := stagedFile.generation
 	stagedFile.flushing = true
 	stagedFile.shouldFlush = true
 	flushWeight := fs.flags.MaxParallelParts
@@ -1753,15 +1747,15 @@ func (fs *Goofys) flushStagedFileDirect(inode *Inode) (err error) {
 	}
 	contentType := inode.fs.flags.GetMimeType(inode.FullName())
 	inode.mu.Unlock()
-	defer localFile.Close()
 
+	flushFinished := false
 	defer func() {
+		if !flushFinished {
+			stagedFile.FinishFlush(true)
+		}
 		inode.mu.Lock()
 		inode.IsFlushing -= flushWeight
 		inode.mu.Unlock()
-		if err != nil {
-			stagedFile.ResetFlushForRetry()
-		}
 		fs.WakeupFlusher()
 	}()
 
@@ -1795,6 +1789,13 @@ func (fs *Goofys) flushStagedFileDirect(inode *Inode) (err error) {
 	}
 
 	inode.mu.Lock()
+	if inode.StagedFile != stagedFile {
+		inode.mu.Unlock()
+		stagedFile.FinishFlush(false)
+		flushFinished = true
+		return nil
+	}
+
 	inode.recordFlushError(nil)
 	inode.updateFromFlush(totalSize, resp.ETag, resp.LastModified, resp.StorageClass)
 	inode.userMetadataDirty = 0
@@ -1808,28 +1809,54 @@ func (fs *Goofys) flushStagedFileDirect(inode *Inode) (err error) {
 			inode.SetCacheState(ST_MODIFIED)
 		}
 	}
-	inode.mu.Unlock()
-
-	inode.mu.Lock()
-	var size uint64
-	size = inode.Attributes.Size
-	localPath, hasLocalPath := stagedFile.Path()
-	if inode.StagedFile == stagedFile {
+	stagedFile.mu.Lock()
+	generationChanged := stagedFile.generation != flushGeneration
+	pendingRemoteRename := !generationChanged && inode.oldParent != nil
+	if generationChanged {
+		stagedFile.awaitingRemoteRename = false
+		stagedFile.shouldFlush = true
+		if inode.CacheState == ST_CACHED {
+			inode.SetCacheState(ST_MODIFIED)
+		}
+	} else if pendingRemoteRename {
+		stagedFile.awaitingRemoteRename = true
+		stagedFile.shouldFlush = false
+	} else {
 		inode.StagedFile = nil
 		inode.fs.stagedFiles.Delete(inode.Id)
 	}
+	stagedFile.mu.Unlock()
+	size := inode.Attributes.Size
 	inode.mu.Unlock()
 
+	stagedFile.FinishFlush(generationChanged)
+	flushFinished = true
+
+	if generationChanged {
+		log.Debugf("Direct staged file changed during flush; retaining generation for retry: inode=%s size=%d", inode.FullName(), totalSize)
+		return nil
+	}
+	if pendingRemoteRename {
+		log.Debugf("Direct staged file upload complete; retaining generation through remote rename: inode=%s size=%d", inode.FullName(), totalSize)
+		return nil
+	}
+
+	preserveForCache := fs.finalizeStagedFile(inode, stagedFile, hash, size)
+	log.Debugf("Direct staged file flush complete: inode=%s size=%d hash=%s preserved_for_cache=%v", inode.FullName(), totalSize, string(hash), preserveForCache)
+	return nil
+}
+
+func (fs *Goofys) finalizeStagedFile(inode *Inode, stagedFile *StagedFile, hash []byte, size uint64) bool {
+	localPath, hasLocalPath := stagedFile.Path()
 	preserveForCache := false
-	if fs.flags.CacheThroughModeEnabled && fs.flags.ExternalCacheClient != nil && hasLocalPath {
-		preserveForCache = fs.CacheFileInExternalCacheFromSource(inode, localPath, true)
+	if fs.flags.CacheThroughModeEnabled && fs.flags.ExternalCacheClient != nil && hasLocalPath && len(hash) > 0 {
+		preserveForCache = fs.queueLocalFileForExternalCache(inode, localPath, string(hash), size)
 		if preserveForCache {
 			stagedFile.PreserveForCache(localPath)
 		}
 	}
 
 	stagedFile.Cleanup()
-
 	if fs.flags.EventCallback != nil {
 		fs.flags.EventCallback(cfg.EventStagedFileUploaded, map[string]interface{}{
 			"inode": stagedFile.FH.inode.FullName(),
@@ -1837,9 +1864,32 @@ func (fs *Goofys) flushStagedFileDirect(inode *Inode) (err error) {
 			"size":  size,
 		})
 	}
+	return preserveForCache
+}
 
-	log.Debugf("Direct staged file flush complete: inode=%s size=%d hash=%s preserved_for_cache=%v", inode.FullName(), totalSize, string(hash), preserveForCache)
-	return nil
+func (fs *Goofys) queueLocalFileForExternalCache(inode *Inode, localPath, hash string, size uint64) bool {
+	if !fs.reserveExternalCacheStore(inode, hash) {
+		return false
+	}
+
+	event := cacheEvent{
+		path:             inode.FullName(),
+		size:             size,
+		hash:             hash,
+		inode:            inode,
+		localSourcePath:  localPath,
+		removeLocalAfter: true,
+	}
+	select {
+	case fs.cacheEventChan <- event:
+		atomic.AddInt64(&fs.stats.cacheEventsQueued, 1)
+		return true
+	default:
+		log.Warnf("External cache event queue is full, skipping cache for %v", inode.FullName())
+		atomic.AddInt64(&fs.stats.cacheEventsDropped, 1)
+		fs.clearCachingStatus(hash)
+		return false
+	}
 }
 
 func hashLocalFile(file *os.File, size uint64) (string, error) {
@@ -2026,7 +2076,9 @@ func (fs *Goofys) WaitForFlush() {
 					)
 
 					hasStaged = true
-					if stagedFile.flushing {
+					if stagedFile.AwaitingRemoteRename() {
+						startedFlush = inode.TryFlush(1)
+					} else if stagedFile.flushing {
 					} else {
 						// Shutdown/unmount must persist every staged file regardless
 						// of the debounce window, otherwise recent writes can remain

--- a/core/goofys_fs_test.go
+++ b/core/goofys_fs_test.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"syscall"
 	"time"
 
@@ -592,6 +593,75 @@ func (s *GoofysTest) TestSlurpLookupNoCloud(t *C) {
 
 	_, err = s.fs.LookupPath("testdir")
 	t.Assert(err, IsNil)
+}
+
+func (s *GoofysTest) TestReadDirNoPreloadScopedNoCloud(t *C) {
+	flags := cfg.DefaultFlags()
+	flags.NoPreloadDir = true
+
+	targetPrefix := "workspace/models/snapshots/revision/"
+	type listRequest struct {
+		prefix    string
+		delimiter string
+		maxKeys   uint32
+	}
+	var mu sync.Mutex
+	var requests []listRequest
+
+	backend := &TestBackend{
+		err: syscall.ENOENT,
+		HeadBlobFunc: func(*HeadBlobInput) (*HeadBlobOutput, error) {
+			return nil, syscall.ENOENT
+		},
+		ListBlobsFunc: func(param *ListBlobsInput) (*ListBlobsOutput, error) {
+			request := listRequest{
+				prefix:    NilStr(param.Prefix),
+				delimiter: NilStr(param.Delimiter),
+				maxKeys:   NilUInt32(param.MaxKeys),
+			}
+			mu.Lock()
+			requests = append(requests, request)
+			mu.Unlock()
+
+			if request.maxKeys == 1 {
+				return &ListBlobsOutput{
+					Prefixes: []BlobPrefixOutput{{Prefix: PString(request.prefix)}},
+				}, nil
+			}
+			if request.prefix == targetPrefix && request.delimiter == "/" {
+				return &ListBlobsOutput{
+					Items: []BlobItemOutput{{
+						Key:  PString(targetPrefix + "model.safetensors"),
+						Size: 5,
+					}},
+				}, nil
+			}
+			return nil, syscall.EINVAL
+		},
+	}
+
+	fs, err := newGoofys(context.Background(), "test", flags, func(string, *cfg.FlagStorage) (StorageBackend, error) {
+		return backend, nil
+	})
+	t.Assert(err, IsNil)
+
+	inode, err := fs.LookupPath("workspace/models/snapshots/revision")
+	t.Assert(err, IsNil)
+	dh := inode.OpenDir()
+	t.Assert(namesOf(s.readDirFully(t, dh)), DeepEquals, []string{"model.safetensors"})
+	t.Assert(dh.CloseDir(), IsNil)
+
+	mu.Lock()
+	defer mu.Unlock()
+	scopedListings := 0
+	for _, request := range requests {
+		if request.maxKeys == 0 {
+			t.Assert(request.prefix, Equals, targetPrefix)
+			t.Assert(request.delimiter, Equals, "/")
+			scopedListings++
+		}
+	}
+	t.Assert(scopedListings, Equals, 1)
 }
 
 // Case # 1 - check that a directory longer than eviction limit is listed correctly

--- a/core/handles.go
+++ b/core/handles.go
@@ -88,6 +88,7 @@ type MPUPart struct {
 type StagedFile struct {
 	FH          *FileHandle
 	FD          *os.File
+	localPath   string
 	mu          sync.Mutex
 	lastWriteAt time.Time
 	lastReadAt  time.Time
@@ -134,7 +135,7 @@ func (stagedFile *StagedFile) Cleanup() {
 	}
 
 	fh := stagedFile.FH
-	fullPath := stagedFile.FD.Name()
+	fullPath, _ := stagedFile.pathLocked()
 	removePath := stagedFile.cachePath == ""
 	log.Debugf("Cleaning up staged file: %s", fh.inode.FullName())
 	stagedFile.FD.Close()
@@ -156,12 +157,37 @@ func (stagedFile *StagedFile) Cleanup() {
 func (stagedFile *StagedFile) Path() (string, bool) {
 	stagedFile.mu.Lock()
 	defer stagedFile.mu.Unlock()
+	return stagedFile.pathLocked()
+}
+
+func (stagedFile *StagedFile) pathLocked() (string, bool) {
 
 	if stagedFile.FD == nil {
 		return "", false
 	}
 
+	if stagedFile.localPath != "" {
+		return stagedFile.localPath, true
+	}
 	return stagedFile.FD.Name(), true
+}
+
+func (stagedFile *StagedFile) moveTo(path string) error {
+	stagedFile.mu.Lock()
+	defer stagedFile.mu.Unlock()
+
+	oldPath, ok := stagedFile.pathLocked()
+	if !ok {
+		return nil
+	}
+	if oldPath == path {
+		return nil
+	}
+	if err := os.Rename(oldPath, path); err != nil {
+		return err
+	}
+	stagedFile.localPath = path
+	return nil
 }
 
 func (stagedFile *StagedFile) PreserveForCache(path string) {

--- a/core/handles.go
+++ b/core/handles.go
@@ -86,23 +86,25 @@ type MPUPart struct {
 }
 
 type StagedFile struct {
-	FH          *FileHandle
-	FD          *os.File
-	localPath   string
-	mu          sync.Mutex
-	lastWriteAt time.Time
-	lastReadAt  time.Time
-	shouldFlush bool
-	flushing    bool
-	debounce    time.Duration
-	cachePath   string
+	FH                   *FileHandle
+	FD                   *os.File
+	mu                   sync.Mutex
+	lastWriteAt          time.Time
+	lastReadAt           time.Time
+	shouldFlush          bool
+	flushing             bool
+	cleanupPending       bool
+	awaitingRemoteRename bool
+	generation           uint64
+	debounce             time.Duration
+	cachePath            string
 }
 
 func (stagedFile *StagedFile) ReadyToFlush() bool {
 	stagedFile.mu.Lock()
 	defer stagedFile.mu.Unlock()
 
-	if stagedFile.flushing {
+	if stagedFile.flushing || stagedFile.awaitingRemoteRename {
 		return false
 	}
 
@@ -130,28 +132,39 @@ func (stagedFile *StagedFile) Cleanup() {
 	if stagedFile.FD == nil {
 		stagedFile.flushing = false
 		stagedFile.shouldFlush = false
+		stagedFile.cleanupPending = false
+		stagedFile.awaitingRemoteRename = false
+		stagedFile.mu.Unlock()
+		return
+	}
+	if stagedFile.flushing {
+		stagedFile.cleanupPending = true
 		stagedFile.mu.Unlock()
 		return
 	}
 
 	fh := stagedFile.FH
-	fullPath, _ := stagedFile.pathLocked()
-	removePath := stagedFile.cachePath == ""
+	fullPath := stagedFile.FD.Name()
+	removePath := stagedFile.cachePath == "" && stagedFile.ownsPathLocked(fullPath)
 	log.Debugf("Cleaning up staged file: %s", fh.inode.FullName())
 	stagedFile.FD.Close()
 	stagedFile.FD = nil
 	stagedFile.flushing = false
 	stagedFile.shouldFlush = false
+	stagedFile.cleanupPending = false
+	stagedFile.awaitingRemoteRename = false
 	stagedFile.mu.Unlock()
 
+	removed := false
 	if removePath {
-		err := os.RemoveAll(fullPath)
-		if err != nil {
+		err := os.Remove(fullPath)
+		removed = err == nil || os.IsNotExist(err)
+		if !removed {
 			log.Warnf("Failed to remove staged file: %v", err)
 		}
 	}
 
-	log.Debugf("Removed staged file: %s", fh.inode.FullName())
+	log.Debugf("Staged file cleanup complete: inode=%s path=%s removed=%t", fh.inode.FullName(), fullPath, removed)
 }
 
 func (stagedFile *StagedFile) Path() (string, bool) {
@@ -161,33 +174,24 @@ func (stagedFile *StagedFile) Path() (string, bool) {
 }
 
 func (stagedFile *StagedFile) pathLocked() (string, bool) {
-
 	if stagedFile.FD == nil {
 		return "", false
 	}
 
-	if stagedFile.localPath != "" {
-		return stagedFile.localPath, true
+	path := stagedFile.FD.Name()
+	if !stagedFile.ownsPathLocked(path) {
+		return "", false
 	}
-	return stagedFile.FD.Name(), true
+	return path, true
 }
 
-func (stagedFile *StagedFile) moveTo(path string) error {
-	stagedFile.mu.Lock()
-	defer stagedFile.mu.Unlock()
-
-	oldPath, ok := stagedFile.pathLocked()
-	if !ok {
-		return nil
+func (stagedFile *StagedFile) ownsPathLocked(path string) bool {
+	fdInfo, err := stagedFile.FD.Stat()
+	if err != nil {
+		return false
 	}
-	if oldPath == path {
-		return nil
-	}
-	if err := os.Rename(oldPath, path); err != nil {
-		return err
-	}
-	stagedFile.localPath = path
-	return nil
+	pathInfo, err := os.Stat(path)
+	return err == nil && os.SameFile(fdInfo, pathInfo)
 }
 
 func (stagedFile *StagedFile) PreserveForCache(path string) {
@@ -197,14 +201,38 @@ func (stagedFile *StagedFile) PreserveForCache(path string) {
 	stagedFile.cachePath = path
 }
 
-func (stagedFile *StagedFile) ResetFlushForRetry() {
+func (stagedFile *StagedFile) FinishFlush(retry bool) {
 	stagedFile.mu.Lock()
-	defer stagedFile.mu.Unlock()
-
-	if stagedFile.FD != nil {
-		stagedFile.flushing = false
+	stagedFile.flushing = false
+	if retry && stagedFile.FD != nil && !stagedFile.cleanupPending {
 		stagedFile.shouldFlush = true
 	}
+	cleanup := stagedFile.cleanupPending
+	stagedFile.mu.Unlock()
+
+	if cleanup {
+		stagedFile.Cleanup()
+	}
+}
+
+func (stagedFile *StagedFile) AwaitingRemoteRename() bool {
+	stagedFile.mu.Lock()
+	defer stagedFile.mu.Unlock()
+	return stagedFile.FD != nil && stagedFile.awaitingRemoteRename
+}
+
+func (stagedFile *StagedFile) PrepareDirectUpload() bool {
+	stagedFile.mu.Lock()
+	defer stagedFile.mu.Unlock()
+	if stagedFile.FD == nil || stagedFile.cleanupPending {
+		return false
+	}
+
+	stagedFile.awaitingRemoteRename = false
+	stagedFile.shouldFlush = true
+	stagedFile.lastWriteAt = time.Time{}
+	stagedFile.lastReadAt = time.Time{}
+	return true
 }
 
 type Inode struct {

--- a/core/staged_cache_test.go
+++ b/core/staged_cache_test.go
@@ -573,6 +573,214 @@ func newStagedInodeForFlush(t *testing.T, fs *Goofys, root *Inode, data []byte) 
 	return inode, stagedPath
 }
 
+type stagedRenameBackend struct {
+	TestBackend
+	deleteBlob func(*DeleteBlobInput) (*DeleteBlobOutput, error)
+}
+
+func (b *stagedRenameBackend) DeleteBlob(param *DeleteBlobInput) (*DeleteBlobOutput, error) {
+	if b.deleteBlob != nil {
+		return b.deleteBlob(param)
+	}
+	return b.TestBackend.DeleteBlob(param)
+}
+
+func newStagedRenameInode(t *testing.T, fs *Goofys, root *Inode, name string, data []byte) (*Inode, string) {
+	t.Helper()
+
+	inode := NewInode(fs, root, name)
+	inode.Id = 2
+	inode.SetCacheState(ST_CREATED)
+	inode.Attributes.Size = uint64(len(data))
+	root.insertChild(inode)
+
+	stagedPath := filepath.Join(fs.flags.StagedWritePath, name)
+	if err := os.MkdirAll(filepath.Dir(stagedPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	fd, err := os.OpenFile(stagedPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fd.WriteAt(data, 0); err != nil {
+		t.Fatal(err)
+	}
+	inode.StagedFile = &StagedFile{
+		FH:          NewFileHandle(inode),
+		FD:          fd,
+		localPath:   stagedPath,
+		lastWriteAt: time.Now().Add(-time.Second),
+		lastReadAt:  time.Now().Add(-time.Second),
+	}
+	fs.stagedFiles.Store(inode.Id, inode)
+	return inode, stagedPath
+}
+
+func TestStagedRenameBeforeFlushUploadsFinalKey(t *testing.T) {
+	const (
+		oldName = "model.safetensors.incomplete"
+		newName = "model.safetensors"
+	)
+	payload := []byte("model weights")
+	var uploadedKey string
+	backend := &stagedRenameBackend{}
+	backend.PutBlobFunc = func(param *PutBlobInput) (*PutBlobOutput, error) {
+		uploadedKey = param.Key
+		got, err := io.ReadAll(param.Body)
+		if err != nil {
+			return nil, err
+		}
+		if !bytes.Equal(got, payload) {
+			t.Fatalf("uploaded data = %q, want %q", got, payload)
+		}
+		now := time.Now()
+		return &PutBlobOutput{ETag: PString("etag"), LastModified: &now}, nil
+	}
+
+	flags := cfg.DefaultFlags()
+	flags.HashAttr = ""
+	flags.StagedWritePath = t.TempDir()
+	fs := newUnitFS(flags)
+	root := newRootWithBackend(fs, backend)
+	inode, oldPath := newStagedRenameInode(t, fs, root, oldName, payload)
+
+	if err := root.Rename(oldName, root, newName); err != nil {
+		t.Fatal(err)
+	}
+	newPath := filepath.Join(flags.StagedWritePath, newName)
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("old staged path still exists: %v", err)
+	}
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("renamed staged path is unavailable: %v", err)
+	}
+
+	if err := fs.flushStagedFile(inode); err != nil {
+		t.Fatal(err)
+	}
+	if uploadedKey != newName {
+		t.Fatalf("uploaded key = %q, want %q", uploadedKey, newName)
+	}
+	if inode.oldParent != nil {
+		t.Fatal("rename before flush should not require a remote rename")
+	}
+	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+		t.Fatalf("staged path was not cleaned up: %v", err)
+	}
+}
+
+func TestStagedRenameDuringFlushCompletesRemoteRename(t *testing.T) {
+	const (
+		oldName = "model.safetensors.incomplete"
+		newName = "model.safetensors"
+	)
+	payload := []byte("model weights")
+	uploadStarted := make(chan string, 1)
+	releaseUpload := make(chan struct{})
+	uploaded := make(chan []byte, 1)
+	copied := make(chan *CopyBlobInput, 1)
+	deleted := make(chan string, 1)
+	backend := &stagedRenameBackend{}
+	backend.PutBlobFunc = func(param *PutBlobInput) (*PutBlobOutput, error) {
+		uploadStarted <- param.Key
+		<-releaseUpload
+		data, err := io.ReadAll(param.Body)
+		if err != nil {
+			return nil, err
+		}
+		uploaded <- data
+		now := time.Now()
+		return &PutBlobOutput{ETag: PString("etag"), LastModified: &now}, nil
+	}
+	backend.CopyBlobFunc = func(param *CopyBlobInput) (*CopyBlobOutput, error) {
+		copied <- param
+		return &CopyBlobOutput{}, nil
+	}
+	backend.deleteBlob = func(param *DeleteBlobInput) (*DeleteBlobOutput, error) {
+		deleted <- param.Key
+		return &DeleteBlobOutput{}, nil
+	}
+
+	flags := cfg.DefaultFlags()
+	flags.HashAttr = ""
+	flags.StagedWritePath = t.TempDir()
+	fs := newUnitFS(flags)
+	root := newRootWithBackend(fs, backend)
+	inode, oldPath := newStagedRenameInode(t, fs, root, oldName, payload)
+
+	flushDone := make(chan error, 1)
+	go func() {
+		flushDone <- fs.flushStagedFile(inode)
+	}()
+
+	select {
+	case key := <-uploadStarted:
+		if key != oldName {
+			t.Fatalf("upload started at key %q, want %q", key, oldName)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for staged upload")
+	}
+
+	if err := root.Rename(oldName, root, newName); err != nil {
+		t.Fatal(err)
+	}
+	newPath := filepath.Join(flags.StagedWritePath, newName)
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("old staged path still exists during upload: %v", err)
+	}
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("renamed staged path is unavailable during upload: %v", err)
+	}
+	close(releaseUpload)
+
+	select {
+	case err := <-flushDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for staged flush")
+	}
+	if got := <-uploaded; !bytes.Equal(got, payload) {
+		t.Fatalf("uploaded data = %q, want %q", got, payload)
+	}
+
+	inode.mu.Lock()
+	oldParent := inode.oldParent
+	flushes := inode.IsFlushing
+	inode.mu.Unlock()
+	if oldParent != root {
+		t.Fatal("rename during flush did not retain the old object location")
+	}
+	if flushes != 0 {
+		t.Fatalf("staged flush marker = %d, want 0", flushes)
+	}
+	if !inode.TryFlush(1) {
+		t.Fatal("remote rename was not scheduled")
+	}
+
+	select {
+	case copyInput := <-copied:
+		if copyInput.Source != oldName || copyInput.Destination != newName {
+			t.Fatalf("remote copy = %q -> %q, want %q -> %q", copyInput.Source, copyInput.Destination, oldName, newName)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for remote copy")
+	}
+	select {
+	case key := <-deleted:
+		if key != oldName {
+			t.Fatalf("deleted key = %q, want %q", key, oldName)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for old object deletion")
+	}
+	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+		t.Fatalf("staged path was not cleaned up: %v", err)
+	}
+}
+
 func TestExternalCacheShortStreamFallsBackWithoutZeroPadding(t *testing.T) {
 	want := []byte("hello world")
 	flags := cfg.DefaultFlags()

--- a/core/staged_cache_test.go
+++ b/core/staged_cache_test.go
@@ -239,6 +239,69 @@ func TestStagedFileCleanupIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestStagedFileCleanupDoesNotRemoveReplacement(t *testing.T) {
+	flags := cfg.DefaultFlags()
+	fs := newUnitFS(flags)
+	inode := &Inode{Name: "file", fs: fs}
+	stagedPath := filepath.Join(t.TempDir(), "file")
+	fd, err := os.OpenFile(stagedPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fd.Write([]byte("old generation")); err != nil {
+		t.Fatal(err)
+	}
+	stagedFile := &StagedFile{FH: &FileHandle{inode: inode}, FD: fd}
+
+	replacementPath := stagedPath + ".replacement"
+	if err := os.WriteFile(replacementPath, []byte("new generation"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(replacementPath, stagedPath); err != nil {
+		t.Fatal(err)
+	}
+
+	stagedFile.Cleanup()
+
+	got, err := os.ReadFile(stagedPath)
+	if err != nil {
+		t.Fatalf("replacement was removed by stale cleanup: %v", err)
+	}
+	if string(got) != "new generation" {
+		t.Fatalf("replacement data = %q, want new generation", got)
+	}
+}
+
+func TestStagedFilesUseUniquePathsAcrossMounts(t *testing.T) {
+	stagedWritePath := t.TempDir()
+	newStagedFile := func() *StagedFile {
+		flags := cfg.DefaultFlags()
+		flags.StagedWritePath = stagedWritePath
+		fs := newUnitFS(flags)
+		root := newRootWithBackend(fs, &TestBackend{})
+		inode := NewInode(fs, root, "main")
+		inode.Id = 2
+		fh := NewFileHandle(inode)
+		if err := fh.getOrCreateStagedFile(); err != nil {
+			t.Fatal(err)
+		}
+		return inode.StagedFile
+	}
+
+	first := newStagedFile()
+	second := newStagedFile()
+	firstPath, firstOK := first.Path()
+	secondPath, secondOK := second.Path()
+	if !firstOK || !secondOK {
+		t.Fatal("staged generation path is unavailable")
+	}
+	if firstPath == secondPath {
+		t.Fatalf("independent mounts shared staged path %q", firstPath)
+	}
+	first.Cleanup()
+	second.Cleanup()
+}
+
 func TestNoSuchUploadPreservesStagedData(t *testing.T) {
 	flags := cfg.DefaultFlags()
 	fs := newUnitFS(flags)
@@ -510,6 +573,64 @@ func TestSuccessfulStagedFlushEmitsOneUploadEvent(t *testing.T) {
 	}
 }
 
+func TestSuccessfulStagedFlushPublishesFromItsGenerationPath(t *testing.T) {
+	payload := []byte("cached staged content")
+	sum := sha256.Sum256(payload)
+	expectedHash := hex.EncodeToString(sum[:])
+	flags := cfg.DefaultFlags()
+	flags.HashAttr = "sha256"
+	flags.MinFileSizeForHashKB = 0
+	flags.CacheThroughModeEnabled = true
+	flags.ExternalCacheClient = &fakeContentCache{
+		storeLocalPath: func(source struct {
+			Path      string
+			CachePath string
+		}, opts struct {
+			RoutingKey string
+			Lock       bool
+		}) (string, error) {
+			got, err := os.ReadFile(source.Path)
+			if err != nil {
+				return "", err
+			}
+			if !bytes.Equal(got, payload) {
+				t.Fatalf("cache source = %q, want %q", got, payload)
+			}
+			return opts.RoutingKey, nil
+		},
+	}
+	fs := newUnitFS(flags)
+	backend := &TestBackend{}
+	backend.PutBlobFunc = func(param *PutBlobInput) (*PutBlobOutput, error) {
+		if _, err := io.Copy(io.Discard, param.Body); err != nil {
+			return nil, err
+		}
+		now := time.Now()
+		return &PutBlobOutput{ETag: PString("etag"), LastModified: &now}, nil
+	}
+	root := newRootWithBackend(fs, backend)
+	inode, stagedPath := newStagedInodeForFlush(t, fs, root, payload)
+
+	if err := fs.flushStagedFile(inode); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(stagedPath); err != nil {
+		t.Fatalf("staged generation was removed before cache publication: %v", err)
+	}
+	select {
+	case event := <-fs.cacheEventChan:
+		if event.hash != expectedHash || event.localSourcePath != stagedPath || !event.removeLocalAfter {
+			t.Fatalf("unexpected staged cache event: %+v", event)
+		}
+		fs.processCacheEvent(event)
+	default:
+		t.Fatal("expected staged cache event")
+	}
+	if _, err := os.Stat(stagedPath); !os.IsNotExist(err) {
+		t.Fatalf("staged generation remained after cache publication: %v", err)
+	}
+}
+
 func TestExternalCacheStoreEventIncludesContentIdentity(t *testing.T) {
 	flags := cfg.DefaultFlags()
 	var gotEvent cfg.EventType
@@ -594,21 +715,21 @@ func newStagedRenameInode(t *testing.T, fs *Goofys, root *Inode, name string, da
 	inode.Attributes.Size = uint64(len(data))
 	root.insertChild(inode)
 
-	stagedPath := filepath.Join(fs.flags.StagedWritePath, name)
-	if err := os.MkdirAll(filepath.Dir(stagedPath), 0755); err != nil {
+	stagedDir := filepath.Join(fs.flags.StagedWritePath, filepath.Dir(name))
+	if err := os.MkdirAll(stagedDir, 0755); err != nil {
 		t.Fatal(err)
 	}
-	fd, err := os.OpenFile(stagedPath, os.O_CREATE|os.O_RDWR, 0600)
+	fd, err := os.CreateTemp(stagedDir, ".geesefs-staged-*")
 	if err != nil {
 		t.Fatal(err)
 	}
+	stagedPath := fd.Name()
 	if _, err := fd.WriteAt(data, 0); err != nil {
 		t.Fatal(err)
 	}
 	inode.StagedFile = &StagedFile{
 		FH:          NewFileHandle(inode),
 		FD:          fd,
-		localPath:   stagedPath,
 		lastWriteAt: time.Now().Add(-time.Second),
 		lastReadAt:  time.Now().Add(-time.Second),
 	}
@@ -647,12 +768,8 @@ func TestStagedRenameBeforeFlushUploadsFinalKey(t *testing.T) {
 	if err := root.Rename(oldName, root, newName); err != nil {
 		t.Fatal(err)
 	}
-	newPath := filepath.Join(flags.StagedWritePath, newName)
-	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
-		t.Fatalf("old staged path still exists: %v", err)
-	}
-	if _, err := os.Stat(newPath); err != nil {
-		t.Fatalf("renamed staged path is unavailable: %v", err)
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Fatalf("staged generation moved during logical rename: %v", err)
 	}
 
 	if err := fs.flushStagedFile(inode); err != nil {
@@ -664,7 +781,7 @@ func TestStagedRenameBeforeFlushUploadsFinalKey(t *testing.T) {
 	if inode.oldParent != nil {
 		t.Fatal("rename before flush should not require a remote rename")
 	}
-	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
 		t.Fatalf("staged path was not cleaned up: %v", err)
 	}
 }
@@ -679,7 +796,9 @@ func TestStagedRenameDuringFlushCompletesRemoteRename(t *testing.T) {
 	releaseUpload := make(chan struct{})
 	uploaded := make(chan []byte, 1)
 	copied := make(chan *CopyBlobInput, 1)
+	releaseCopy := make(chan struct{})
 	deleted := make(chan string, 1)
+	var originReads atomic.Int32
 	backend := &stagedRenameBackend{}
 	backend.PutBlobFunc = func(param *PutBlobInput) (*PutBlobOutput, error) {
 		uploadStarted <- param.Key
@@ -694,7 +813,12 @@ func TestStagedRenameDuringFlushCompletesRemoteRename(t *testing.T) {
 	}
 	backend.CopyBlobFunc = func(param *CopyBlobInput) (*CopyBlobOutput, error) {
 		copied <- param
+		<-releaseCopy
 		return &CopyBlobOutput{}, nil
+	}
+	backend.GetBlobFunc = func(param *GetBlobInput) (*GetBlobOutput, error) {
+		originReads.Add(1)
+		return nil, syscall.ENOENT
 	}
 	backend.deleteBlob = func(param *DeleteBlobInput) (*DeleteBlobOutput, error) {
 		deleted <- param.Key
@@ -703,6 +827,7 @@ func TestStagedRenameDuringFlushCompletesRemoteRename(t *testing.T) {
 
 	flags := cfg.DefaultFlags()
 	flags.HashAttr = ""
+	flags.StagedWriteModeEnabled = true
 	flags.StagedWritePath = t.TempDir()
 	fs := newUnitFS(flags)
 	root := newRootWithBackend(fs, backend)
@@ -725,12 +850,8 @@ func TestStagedRenameDuringFlushCompletesRemoteRename(t *testing.T) {
 	if err := root.Rename(oldName, root, newName); err != nil {
 		t.Fatal(err)
 	}
-	newPath := filepath.Join(flags.StagedWritePath, newName)
-	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
-		t.Fatalf("old staged path still exists during upload: %v", err)
-	}
-	if _, err := os.Stat(newPath); err != nil {
-		t.Fatalf("renamed staged path is unavailable during upload: %v", err)
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Fatalf("staged generation moved during logical rename: %v", err)
 	}
 	close(releaseUpload)
 
@@ -749,12 +870,19 @@ func TestStagedRenameDuringFlushCompletesRemoteRename(t *testing.T) {
 	inode.mu.Lock()
 	oldParent := inode.oldParent
 	flushes := inode.IsFlushing
+	stagedFile := inode.StagedFile
 	inode.mu.Unlock()
 	if oldParent != root {
 		t.Fatal("rename during flush did not retain the old object location")
 	}
 	if flushes != 0 {
 		t.Fatalf("staged flush marker = %d, want 0", flushes)
+	}
+	if stagedFile == nil {
+		t.Fatal("staged generation was discarded before the remote rename completed")
+	}
+	if _, err := os.Stat(oldPath); err != nil {
+		t.Fatalf("staged generation was removed before the remote rename completed: %v", err)
 	}
 	if !inode.TryFlush(1) {
 		t.Fatal("remote rename was not scheduled")
@@ -768,6 +896,19 @@ func TestStagedRenameDuringFlushCompletesRemoteRename(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for remote copy")
 	}
+
+	data, bytesRead, err := NewFileHandle(inode).ReadFile(0, int64(len(payload)))
+	if err != nil {
+		t.Fatalf("read during remote rename failed: %v", err)
+	}
+	if bytesRead != len(payload) || !bytes.Equal(bytes.Join(data, nil), payload) {
+		t.Fatalf("read during remote rename = %q (%d bytes), want %q", bytes.Join(data, nil), bytesRead, payload)
+	}
+	if got := originReads.Load(); got != 0 {
+		t.Fatalf("read during remote rename reached origin %d times", got)
+	}
+	close(releaseCopy)
+
 	select {
 	case key := <-deleted:
 		if key != oldName {
@@ -776,8 +917,263 @@ func TestStagedRenameDuringFlushCompletesRemoteRename(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for old object deletion")
 	}
-	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
 		t.Fatalf("staged path was not cleaned up: %v", err)
+	}
+	inode.mu.Lock()
+	stagedFile = inode.StagedFile
+	inode.mu.Unlock()
+	if stagedFile != nil {
+		t.Fatal("staged generation remained attached after the remote rename completed")
+	}
+}
+
+func TestStagedRenameCopyFailureRetainsReadableLocalGeneration(t *testing.T) {
+	payload := []byte("model revision")
+	uploadStarted := make(chan struct{}, 1)
+	releaseUpload := make(chan struct{})
+	copyAttempted := make(chan struct{}, 1)
+	backend := &stagedRenameBackend{}
+	backend.PutBlobFunc = func(param *PutBlobInput) (*PutBlobOutput, error) {
+		uploadStarted <- struct{}{}
+		<-releaseUpload
+		if _, err := io.Copy(io.Discard, param.Body); err != nil {
+			return nil, err
+		}
+		now := time.Now()
+		return &PutBlobOutput{ETag: PString("etag"), LastModified: &now}, nil
+	}
+	backend.CopyBlobFunc = func(param *CopyBlobInput) (*CopyBlobOutput, error) {
+		copyAttempted <- struct{}{}
+		return nil, errors.New("transient copy failure")
+	}
+
+	flags := cfg.DefaultFlags()
+	flags.HashAttr = ""
+	flags.StagedWriteModeEnabled = true
+	flags.StagedWritePath = t.TempDir()
+	fs := newUnitFS(flags)
+	root := newRootWithBackend(fs, backend)
+	inode, stagedPath := newStagedRenameInode(t, fs, root, "main.tmp", payload)
+
+	flushDone := make(chan error, 1)
+	go func() { flushDone <- fs.flushStagedFile(inode) }()
+	select {
+	case <-uploadStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for staged upload")
+	}
+	if err := root.Rename("main.tmp", root, "main"); err != nil {
+		t.Fatal(err)
+	}
+	close(releaseUpload)
+	if err := <-flushDone; err != nil {
+		t.Fatal(err)
+	}
+	if !inode.TryFlush(1) {
+		t.Fatal("remote rename was not scheduled")
+	}
+	select {
+	case <-copyAttempted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for remote copy attempt")
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		inode.mu.Lock()
+		flushing := inode.IsFlushing
+		stagedFile := inode.StagedFile
+		oldParent := inode.oldParent
+		inode.mu.Unlock()
+		if flushing == 0 {
+			if stagedFile == nil || oldParent == nil {
+				t.Fatal("copy failure discarded the local staged generation")
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for failed remote rename")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if _, err := os.Stat(stagedPath); err != nil {
+		t.Fatalf("copy failure removed the local staged generation: %v", err)
+	}
+	data, bytesRead, err := NewFileHandle(inode).ReadFile(0, int64(len(payload)))
+	if err != nil {
+		t.Fatalf("read after copy failure failed: %v", err)
+	}
+	if bytesRead != len(payload) || !bytes.Equal(bytes.Join(data, nil), payload) {
+		t.Fatalf("read after copy failure = %q (%d bytes), want %q", bytes.Join(data, nil), bytesRead, payload)
+	}
+}
+
+func TestStagedRenameMissingSourceUploadsRetainedGenerationDirectly(t *testing.T) {
+	payload := []byte("model revision")
+	firstUploadStarted := make(chan struct{}, 1)
+	releaseFirstUpload := make(chan struct{})
+	copyAttempted := make(chan struct{}, 1)
+	var mu sync.Mutex
+	var uploadedKeys []string
+	backend := &stagedRenameBackend{}
+	backend.PutBlobFunc = func(param *PutBlobInput) (*PutBlobOutput, error) {
+		mu.Lock()
+		call := len(uploadedKeys)
+		uploadedKeys = append(uploadedKeys, param.Key)
+		mu.Unlock()
+		if call == 0 {
+			firstUploadStarted <- struct{}{}
+			<-releaseFirstUpload
+		}
+		got, err := io.ReadAll(param.Body)
+		if err != nil {
+			return nil, err
+		}
+		if !bytes.Equal(got, payload) {
+			t.Fatalf("uploaded data = %q, want %q", got, payload)
+		}
+		now := time.Now()
+		return &PutBlobOutput{ETag: PString("etag"), LastModified: &now}, nil
+	}
+	backend.CopyBlobFunc = func(param *CopyBlobInput) (*CopyBlobOutput, error) {
+		copyAttempted <- struct{}{}
+		return nil, syscall.ENOENT
+	}
+
+	flags := cfg.DefaultFlags()
+	flags.HashAttr = ""
+	flags.StagedWriteModeEnabled = true
+	flags.StagedWritePath = t.TempDir()
+	fs := newUnitFS(flags)
+	root := newRootWithBackend(fs, backend)
+	inode, stagedPath := newStagedRenameInode(t, fs, root, "main.tmp", payload)
+
+	flushDone := make(chan error, 1)
+	go func() { flushDone <- fs.flushStagedFile(inode) }()
+	select {
+	case <-firstUploadStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for staged upload")
+	}
+	if err := root.Rename("main.tmp", root, "main"); err != nil {
+		t.Fatal(err)
+	}
+	close(releaseFirstUpload)
+	if err := <-flushDone; err != nil {
+		t.Fatal(err)
+	}
+	if !inode.TryFlush(1) {
+		t.Fatal("remote rename was not scheduled")
+	}
+	select {
+	case <-copyAttempted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for remote copy attempt")
+	}
+	waitForInodeFlushes(t, inode, 0)
+
+	if err := fs.flushStagedFile(inode); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	keys := append([]string(nil), uploadedKeys...)
+	mu.Unlock()
+	if len(keys) != 2 || keys[0] != "main.tmp" || keys[1] != "main" {
+		t.Fatalf("uploaded keys = %v, want [main.tmp main]", keys)
+	}
+	if _, err := os.Stat(stagedPath); !os.IsNotExist(err) {
+		t.Fatalf("staged path was not cleaned after direct fallback upload: %v", err)
+	}
+}
+
+func TestStagedWriteDuringFlushRetainsGenerationForRetry(t *testing.T) {
+	initial := []byte("old generation")
+	updated := []byte("new generation")
+	firstUploadStarted := make(chan struct{}, 1)
+	releaseFirstUpload := make(chan struct{})
+	var mu sync.Mutex
+	var uploads [][]byte
+	backend := &stagedRenameBackend{}
+	backend.PutBlobFunc = func(param *PutBlobInput) (*PutBlobOutput, error) {
+		mu.Lock()
+		call := len(uploads)
+		mu.Unlock()
+		if call == 0 {
+			firstUploadStarted <- struct{}{}
+			<-releaseFirstUpload
+		}
+		data, err := io.ReadAll(param.Body)
+		if err != nil {
+			return nil, err
+		}
+		mu.Lock()
+		uploads = append(uploads, data)
+		mu.Unlock()
+		now := time.Now()
+		return &PutBlobOutput{ETag: PString("etag"), LastModified: &now}, nil
+	}
+
+	flags := cfg.DefaultFlags()
+	flags.HashAttr = ""
+	flags.StagedWriteModeEnabled = true
+	flags.StagedWritePath = t.TempDir()
+	fs := newUnitFS(flags)
+	root := newRootWithBackend(fs, backend)
+	inode, stagedPath := newStagedRenameInode(t, fs, root, "file", initial)
+
+	flushDone := make(chan error, 1)
+	go func() { flushDone <- fs.flushStagedFile(inode) }()
+	select {
+	case <-firstUploadStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for staged upload")
+	}
+	if err := inode.StagedFile.FH.WriteFileStaged(0, updated); err != nil {
+		t.Fatal(err)
+	}
+	close(releaseFirstUpload)
+	if err := <-flushDone; err != nil {
+		t.Fatal(err)
+	}
+
+	inode.mu.Lock()
+	stagedFile := inode.StagedFile
+	inode.mu.Unlock()
+	if stagedFile == nil {
+		t.Fatal("write during flush was discarded with the completed upload")
+	}
+	if err := fs.flushStagedFile(inode); err != nil {
+		t.Fatal(err)
+	}
+	mu.Lock()
+	gotUploads := append([][]byte(nil), uploads...)
+	mu.Unlock()
+	if len(gotUploads) != 2 {
+		t.Fatalf("uploads = %d, want 2", len(gotUploads))
+	}
+	if !bytes.Equal(gotUploads[1], updated) {
+		t.Fatalf("retried upload = %q, want %q", gotUploads[1], updated)
+	}
+	if _, err := os.Stat(stagedPath); !os.IsNotExist(err) {
+		t.Fatalf("staged path was not cleaned after stable upload: %v", err)
+	}
+}
+
+func waitForInodeFlushes(t *testing.T, inode *Inode, want int) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		inode.mu.Lock()
+		flushing := inode.IsFlushing
+		inode.mu.Unlock()
+		if flushing == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("inode flush count = %d, want %d", flushing, want)
+		}
+		time.Sleep(time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
## What changed

- retain immutable staged-file generations until remote rename and cache publication finish
- retry writes racing an active flush and transient multipart-copy failures
- upload the retained local generation when a remote copy source disappears
- publish cache-through content from the stable local generation
- make `--no-preload-dir` scope READDIR listings to the requested prefix
- remove a parallel lookup data race and return the first successful result safely

## Root cause

Two independent issues affected model volumes:

1. An atomic rename could replace or release the staged source while GeeseFS was still flushing or copying it remotely. Readers then observed `EIO` even though complete bytes had existed locally.
2. `--no-preload-dir` disabled lookup slurping but not READDIR slurping. A nested Hugging Face glob therefore listed up to 1,000 unrelated objects from the workspace root before opening a local cached model.

The fixes are generic staged-write and namespace behavior. They do not special-case vLLM or Hugging Face.

## Validation

- targeted staged rename, concurrent write, retry, cache publication, and scoped READDIR tests
- `go test ./core -check.f '(DirTest|GoofysTest.Test(ReadDirNoPreloadScoped|SlurpLookup)NoCloud)' -count=1`
- Linux amd64 test-binary compile
- staging generic checkpoint/restore and Qwen restore with valid chat completion
- instrumented 3.09 GB model read: 1.34s at 2.2 GB/s, with packet capture confirming no object-store traffic during the read
- nested model glob: 0.72s, down from roughly 34s